### PR TITLE
(fix): Check for tab updates where tab status is `complete` instead of `loading`

### DIFF
--- a/apply.js
+++ b/apply.js
@@ -155,7 +155,7 @@ async function run() {
   });
 
   chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
-    if (changeInfo.status !== "loading" || !/^http/.test(tab.url)) return;
+    if (changeInfo.status !== "complete" || !/^http/.test(tab.url)) return;
     const tabHostname = (new URL(tab.url)).hostname;
     if (!allowedHostnames.includes(tabHostname)) return;
     chrome.scripting.insertCSS({


### PR DESCRIPTION
When url changes, in Firefox there is no `tabs.onUpdated` event with status `loading` emitted

Fixes #38 