### PR TITLE
(fix): update lucky number tile selector

### DIFF
--- a/patches/newDashboard/styles.css
+++ b/patches/newDashboard/styles.css
@@ -41,8 +41,7 @@
         padding-bottom: 0;
     }
 
-    .tile.box:has(.lucky-number__circle.lucky-number__circle-1),
-    .tile.box:has(.tile__lucky-number) {
+    .tile.box.tile__lucky-number {
         display: none !important;
     }
 

--- a/patches/newDashboard/styles.css
+++ b/patches/newDashboard/styles.css
@@ -41,7 +41,9 @@
         padding-bottom: 0;
     }
 
-    .tile.box.tile__lucky-number {
+    .tile.box.tile__lucky-number,
+    .tile.box:has(.lucky-number__circle.lucky-number__circle-1),
+    .tile.box:has(.tile__lucky-number) {
         display: none !important;
     }
 


### PR DESCRIPTION
Hide wide lucky number field on new dashboard.

Based on the yoper12's comment: https://github.com/banocean/ifv/pull/111#discussion_r2033864583